### PR TITLE
fix(Address missing iam:PassRole in quickstart docs)

### DIFF
--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -196,6 +196,7 @@ On the target account, create an IAM role called ``cinq_role`` and attach the `A
                     "iam:DeletePolicy*",
                     "iam:DeleteRolePolicy",
                     "iam:DetachRolePolicy",
+                    "iam:PassRole",
                     "iam:PutRolePolicy",
                     "iam:SetDefaultPolicyVersion",
                     "iam:UpdateAssumeRolePolicy",


### PR DESCRIPTION
Adds a missing element required if using the VPC Flow Logs Auditor. 

Fixes https://github.com/RiotGames/cinq-auditor-vpc-flowlogs/issues/7